### PR TITLE
Enable pitest on div-validation-service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,12 @@ timestamps {
                     }
                 }
 
+                stage('Mutation Testing (Pitest)') {
+                    onPR {
+                        sh "./gradlew pitest"
+                    }
+                }
+
                 stage('Sonar') {
                     onPR {
                         sh "./gradlew -Dsonar.analysis.mode=preview -Dsonar.host.url=$SONARQUBE_URL sonarqube"

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.17.0'
     id 'jacoco'
     id 'pmd'
+    id "info.solidsoft.pitest" version "1.3.0"
 }
 
 group = 'uk.gov.hmcts.reform.divorce'
@@ -73,6 +74,15 @@ tasks.withType(Checkstyle).each { checkstyleTask ->
     }
 }
 
+pitest {
+    targetClasses = ['uk.gov.hmcts.reform.divorce.validationservice.*']
+    excludedClasses = ['uk.gov.hmcts.reform.divorce.validationservice.ValidationServiceApplication', 'uk.gov.hmcts.reform.divorce.validationservice.domain.*', 'uk.gov.hmcts.reform.divorce.validationservice.config.*', 'uk.gov.hmcts.reform.divorce.validationservice.management.config.*']
+    threads = 4
+    outputFormats = ['XML', 'HTML']
+    timestampedReports = false
+    mutationThreshold = 80
+}
+
 // https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
 dependencyCheck {
     // Specifies if the build should be failed if a CVSS score above a specified level is identified.
@@ -89,7 +99,7 @@ def versions = [
         reformsJavaLogging              : '1.2.0',
         reformsJavaLoggingSpring        : '1.2.0',
         reformsJavaLoggingHttpComponents: '1.2.1',
-        lombok                          : '1.16.16',
+        lombok                          : '1.16.20',
         powerMock                       : '1.7.3',
         puppyCrawl                      : '7.6',
         logstashLogBackEncoder          : '4.8',


### PR DESCRIPTION
Jira ticket Div-1932

Enable Mutation Testion with Pitest. This is part of a POC in Jira ticket Div-1932 about Mutation Testing abilities for CNP Migration.