### PR TITLE
DIV-4835 : Fix PMD/checkstyle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ pmd {
     sourceSets = [sourceSets.main, sourceSets.test]
     reportsDir = file("$project.buildDir/reports/pmd")
     ruleSetFiles = files("ruleset.xml")
+    ruleSets = []
 }
 
 test {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -4,28 +4,26 @@
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
     <description>
-        Ruleset for PDF Service
+        Ruleset for Validation Service
     </description>
-    <rule ref="rulesets/java/basic.xml"/>
-    <rule ref="rulesets/java/braces.xml"/>
-    <rule ref="rulesets/java/design.xml">
-        <exclude name="UseUtilityClass"/>
+
+    <rule ref="category/java/errorprone.xml"/>
+    <rule ref="category/java/multithreading.xml"/>
+    <rule ref="category/java/codestyle.xml">
         <exclude name="ConfusingTernary"/>
-    </rule>
-    <rule ref="rulesets/java/empty.xml"/>
-    <rule ref="rulesets/java/imports.xml">
         <exclude name="TooManyStaticImports"/>
-    </rule>
-    <rule ref="rulesets/java/optimizations.xml">
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="LocalVariableCouldBeFinal"/>
     </rule>
-    <rule ref="rulesets/java/typeresolution.xml"/>
-    <rule ref="rulesets/java/typeresolution.xml/SignatureDeclareThrowsException">
+    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/documentation.xml"/>
+    <rule ref="category/java/design.xml">
+        <exclude name="UseUtilityClass"/>
+    </rule>
+    <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
         <properties>
             <property name="IgnoreJUnitCompletely" value="true"/>
         </properties>
     </rule>
-    <rule ref="rulesets/java/unnecessary.xml"/>
-    <rule ref="rulesets/java/unusedcode.xml"/>
+    <rule ref="category/java/bestpractices.xml"/>
 </ruleset>


### PR DESCRIPTION
# Description
Previously the Gradle build would be polluted with hundreds of lines of warnings about migration of rulesets to new files. This change migrates to the new rulesets and also carries over the rule exclusions that we have. This makes the build output far more readable.

Fixes # 
[DIV-4835 Fix PMD/checkstyle warnings](https://tools.hmcts.net/jira/browse/DIV-4835)

## Type of change
Reduce log pollution

# How Has This Been Tested?
Run command 
```bash
./gradlew clean build
```
from project directory and check build output for occurrence of ruleset migration messages.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
